### PR TITLE
Remove thecodingmachine/safe

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,7 @@
     "psr/clock-implementation": "*",
     "psr/log": "^3",
     "ramsey/uuid": "^4.7",
-    "symfony/finder": "^6.2",
-    "thecodingmachine/safe": "^2.4"
+    "symfony/finder": "^6.2"
   },
   "require-dev": {
     "amphp/phpunit-util": "^3.0",
@@ -50,8 +49,7 @@
     "phpstan/phpstan-strict-rules": "^1.4.4",
     "phpunit/phpunit": "^9.5.27",
     "psr/container": "^2.0",
-    "rector/rector": "^0.15.2",
-    "thecodingmachine/phpstan-safe-rule": "^1.2"
+    "rector/rector": "^0.15.2"
   },
   "config": {
     "sort-packages": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4a7a50b254390a8c262e3a2762431e2",
+    "content-hash": "0c5da9994e3a1fa90e4de0496ca9ec4e",
     "packages": [
         {
             "name": "amphp/amp",
@@ -2060,145 +2060,6 @@
                 }
             ],
             "time": "2022-12-22T17:55:15+00:00"
-        },
-        {
-            "name": "thecodingmachine/safe",
-            "version": "v2.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thecodingmachine/safe.git",
-                "reference": "e788f3d09dcd36f806350aedb77eac348fafadd3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/e788f3d09dcd36f806350aedb77eac348fafadd3",
-                "reference": "e788f3d09dcd36f806350aedb77eac348fafadd3",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^8.0"
-            },
-            "require-dev": {
-                "phpstan/phpstan": "^1.5",
-                "phpunit/phpunit": "^9.5",
-                "squizlabs/php_codesniffer": "^3.2",
-                "thecodingmachine/phpstan-strict-rules": "^1.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.2.x-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "deprecated/apc.php",
-                    "deprecated/array.php",
-                    "deprecated/datetime.php",
-                    "deprecated/libevent.php",
-                    "deprecated/misc.php",
-                    "deprecated/password.php",
-                    "deprecated/mssql.php",
-                    "deprecated/stats.php",
-                    "deprecated/strings.php",
-                    "lib/special_cases.php",
-                    "deprecated/mysqli.php",
-                    "generated/apache.php",
-                    "generated/apcu.php",
-                    "generated/array.php",
-                    "generated/bzip2.php",
-                    "generated/calendar.php",
-                    "generated/classobj.php",
-                    "generated/com.php",
-                    "generated/cubrid.php",
-                    "generated/curl.php",
-                    "generated/datetime.php",
-                    "generated/dir.php",
-                    "generated/eio.php",
-                    "generated/errorfunc.php",
-                    "generated/exec.php",
-                    "generated/fileinfo.php",
-                    "generated/filesystem.php",
-                    "generated/filter.php",
-                    "generated/fpm.php",
-                    "generated/ftp.php",
-                    "generated/funchand.php",
-                    "generated/gettext.php",
-                    "generated/gmp.php",
-                    "generated/gnupg.php",
-                    "generated/hash.php",
-                    "generated/ibase.php",
-                    "generated/ibmDb2.php",
-                    "generated/iconv.php",
-                    "generated/image.php",
-                    "generated/imap.php",
-                    "generated/info.php",
-                    "generated/inotify.php",
-                    "generated/json.php",
-                    "generated/ldap.php",
-                    "generated/libxml.php",
-                    "generated/lzf.php",
-                    "generated/mailparse.php",
-                    "generated/mbstring.php",
-                    "generated/misc.php",
-                    "generated/mysql.php",
-                    "generated/network.php",
-                    "generated/oci8.php",
-                    "generated/opcache.php",
-                    "generated/openssl.php",
-                    "generated/outcontrol.php",
-                    "generated/pcntl.php",
-                    "generated/pcre.php",
-                    "generated/pgsql.php",
-                    "generated/posix.php",
-                    "generated/ps.php",
-                    "generated/pspell.php",
-                    "generated/readline.php",
-                    "generated/rpminfo.php",
-                    "generated/rrd.php",
-                    "generated/sem.php",
-                    "generated/session.php",
-                    "generated/shmop.php",
-                    "generated/sockets.php",
-                    "generated/sodium.php",
-                    "generated/solr.php",
-                    "generated/spl.php",
-                    "generated/sqlsrv.php",
-                    "generated/ssdeep.php",
-                    "generated/ssh2.php",
-                    "generated/stream.php",
-                    "generated/strings.php",
-                    "generated/swoole.php",
-                    "generated/uodbc.php",
-                    "generated/uopz.php",
-                    "generated/url.php",
-                    "generated/var.php",
-                    "generated/xdiff.php",
-                    "generated/xml.php",
-                    "generated/xmlrpc.php",
-                    "generated/yaml.php",
-                    "generated/yaz.php",
-                    "generated/zip.php",
-                    "generated/zlib.php"
-                ],
-                "classmap": [
-                    "lib/DateTime.php",
-                    "lib/DateTimeImmutable.php",
-                    "lib/Exceptions/",
-                    "deprecated/Exceptions/",
-                    "generated/Exceptions/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
-            "support": {
-                "issues": "https://github.com/thecodingmachine/safe/issues",
-                "source": "https://github.com/thecodingmachine/safe/tree/v2.4.0"
-            },
-            "time": "2022-10-07T14:02:17+00:00"
         }
     ],
     "packages-dev": [
@@ -4493,63 +4354,6 @@
                 }
             ],
             "time": "2020-09-28T06:39:44+00:00"
-        },
-        {
-            "name": "thecodingmachine/phpstan-safe-rule",
-            "version": "v1.2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/thecodingmachine/phpstan-safe-rule.git",
-                "reference": "8a7b88e0d54f209a488095085f183e9174c40e1e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/thecodingmachine/phpstan-safe-rule/zipball/8a7b88e0d54f209a488095085f183e9174c40e1e",
-                "reference": "8a7b88e0d54f209a488095085f183e9174c40e1e",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0",
-                "phpstan/phpstan": "^1.0",
-                "thecodingmachine/safe": "^1.0 || ^2.0"
-            },
-            "require-dev": {
-                "php-coveralls/php-coveralls": "^2.1",
-                "phpunit/phpunit": "^7.5.2 || ^8.0",
-                "squizlabs/php_codesniffer": "^3.4"
-            },
-            "type": "phpstan-extension",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.1-dev"
-                },
-                "phpstan": {
-                    "includes": [
-                        "phpstan-safe-rule.neon"
-                    ]
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "TheCodingMachine\\Safe\\PHPStan\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "David Négrier",
-                    "email": "d.negrier@thecodingmachine.com"
-                }
-            ],
-            "description": "A PHPStan rule to detect safety issues. Must be used in conjunction with thecodingmachine/safe",
-            "support": {
-                "issues": "https://github.com/thecodingmachine/phpstan-safe-rule/issues",
-                "source": "https://github.com/thecodingmachine/phpstan-safe-rule/tree/v1.2.0"
-            },
-            "time": "2022-01-17T10:12:29+00:00"
         },
         {
             "name": "theseer/tokenizer",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,6 @@ includes:
   - vendor/phpstan/phpstan-phpunit/extension.neon
   - vendor/phpstan/phpstan-phpunit/rules.neon
   - vendor/phpstan/phpstan-strict-rules/rules.neon
-  - vendor/thecodingmachine/phpstan-safe-rule/phpstan-safe-rule.neon
   - vendor/php-standard-library/phpstan-extension/extension.neon
 
 parameters:

--- a/src/ClassDiscovery/ReadableDirectory.php
+++ b/src/ClassDiscovery/ReadableDirectory.php
@@ -14,7 +14,8 @@ final class ReadableDirectory
         \assert(\is_readable($directory));
         \assert($directory[\strlen($directory) - 1] !== \DIRECTORY_SEPARATOR);
 
-        $realPath = \Safe\realpath($directory);
+        $realPath = \realpath($directory);
+        \assert(\is_string($realPath));
         $this->directory = $realPath;
     }
 

--- a/tests/unit/Migration/Revision/RevisionClassNameGeneratorTest.php
+++ b/tests/unit/Migration/Revision/RevisionClassNameGeneratorTest.php
@@ -8,7 +8,6 @@ use BenChallis\SqlMigrations\Migration\Revision\RevisionClassNameGenerator;
 use Lendable\Clock\FixedClock;
 use Lendable\Clock\SystemClock;
 use PHPUnit\Framework\TestCase;
-use Safe\DateTimeImmutable;
 
 /**
  * @covers \BenChallis\SqlMigrations\Migration\Revision\RevisionClassNameGenerator
@@ -45,7 +44,7 @@ final class RevisionClassNameGeneratorTest extends TestCase
      */
     public function will_create_a_class_name_with_the_current_timestamp_and_description(): void
     {
-        $clock = new FixedClock(new DateTimeImmutable('2022-10-11 12:32:41'));
+        $clock = new FixedClock(new \DateTimeImmutable('2022-10-11 12:32:41'));
         $generator = new RevisionClassNameGenerator($clock);
 
         $className = $generator->generate('FooBarBaz');


### PR DESCRIPTION
As this is a library we should not enforce safe being used as:

* Small amount of actual usage at runtime that can be replaced with manual assertions
* Requires runtime code to load its functions, which has a runtime performance impact (even if small).