### PR TITLE
Remove php-parallel-lint/php-parallel-lint

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,7 +41,6 @@
     "ergebnis/phpstan-rules": "^1.0",
     "lendable/clock": "^2.3",
     "php-cs-fixer/shim": "^v3.13.1",
-    "php-parallel-lint/php-parallel-lint": "^1.3",
     "php-standard-library/phpstan-extension": "^1.0",
     "phpstan/phpstan": "^1.9.4",
     "phpstan/phpstan-deprecation-rules": "^1.1.1",
@@ -64,13 +63,6 @@
     "code-style:check": [
       "PHP_CS_FIXER_FUTURE_MODE=1 php-cs-fixer fix --dry-run --diff --ansi"
     ],
-    "lint:php": [
-      "parallel-lint src",
-      "parallel-lint tests"
-    ],
-    "lint": [
-      "@lint:php"
-    ],
     "phpstan": [
       "phpstan analyse --memory-limit=-1 --ansi"
     ],
@@ -79,7 +71,6 @@
     ],
     "static-analysis": [
       "@composer validate",
-      "@lint",
       "@phpstan",
       "@rector"
     ],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0c5da9994e3a1fa90e4de0496ca9ec4e",
+    "content-hash": "0987c88eb799b7796c74dcdabeb64c05",
     "packages": [
         {
             "name": "amphp/amp",
@@ -2544,63 +2544,6 @@
                 "source": "https://github.com/PHP-CS-Fixer/shim/tree/v3.13.1"
             },
             "time": "2022-12-18T00:48:28+00:00"
-        },
-        {
-            "name": "php-parallel-lint/php-parallel-lint",
-            "version": "v1.3.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-parallel-lint/PHP-Parallel-Lint.git",
-                "reference": "6483c9832e71973ed29cf71bd6b3f4fde438a9de"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Parallel-Lint/zipball/6483c9832e71973ed29cf71bd6b3f4fde438a9de",
-                "reference": "6483c9832e71973ed29cf71bd6b3f4fde438a9de",
-                "shasum": ""
-            },
-            "require": {
-                "ext-json": "*",
-                "php": ">=5.3.0"
-            },
-            "replace": {
-                "grogy/php-parallel-lint": "*",
-                "jakub-onderka/php-parallel-lint": "*"
-            },
-            "require-dev": {
-                "nette/tester": "^1.3 || ^2.0",
-                "php-parallel-lint/php-console-highlighter": "0.* || ^1.0",
-                "squizlabs/php_codesniffer": "^3.6"
-            },
-            "suggest": {
-                "php-parallel-lint/php-console-highlighter": "Highlight syntax in code snippet"
-            },
-            "bin": [
-                "parallel-lint"
-            ],
-            "type": "library",
-            "autoload": {
-                "classmap": [
-                    "./src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jakub Onderka",
-                    "email": "ahoj@jakubonderka.cz"
-                }
-            ],
-            "description": "This tool check syntax of PHP files about 20x faster than serial check.",
-            "homepage": "https://github.com/php-parallel-lint/PHP-Parallel-Lint",
-            "support": {
-                "issues": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/issues",
-                "source": "https://github.com/php-parallel-lint/PHP-Parallel-Lint/tree/v1.3.2"
-            },
-            "time": "2022-02-21T12:50:22+00:00"
         },
         {
             "name": "php-standard-library/phpstan-extension",


### PR DESCRIPTION
Rely on PHPStan to detect unparsable code instead.