### PR TITLE
Sort migrations ascending on version in InMemoryMigrations

### DIFF
--- a/src/Migration/InMemoryMigrations.php
+++ b/src/Migration/InMemoryMigrations.php
@@ -9,6 +9,7 @@ use Psl\Collection\MapInterface;
 use Psl\Collection\MutableMap;
 use Psl\Collection\Vector;
 use Psl\Collection\VectorInterface;
+use Psl\Dict;
 
 final class InMemoryMigrations implements Migrations
 {
@@ -22,7 +23,7 @@ final class InMemoryMigrations implements Migrations
      */
     public function __construct(MapInterface $map)
     {
-        $this->map = new MutableMap($map->toArray());
+        $this->map = new MutableMap(Dict\sort_by_key($map->toArray()));
     }
 
     public function getAll(): VectorInterface

--- a/tests/helper/MigrationAsserter.php
+++ b/tests/helper/MigrationAsserter.php
@@ -49,4 +49,14 @@ final class MigrationAsserter
 
         return $this;
     }
+
+    /**
+     * @param class-string<Revision> $revisionClass
+     */
+    public function hasRevisionClass(string $revisionClass): self
+    {
+        Assert::assertInstanceOf($revisionClass, $this->migration->revision);
+
+        return $this;
+    }
 }

--- a/tests/spec/MigrationsSpec.php
+++ b/tests/spec/MigrationsSpec.php
@@ -17,6 +17,7 @@ use Psl\Collection\VectorInterface;
 use Tests\Fixtures\BenChallis\SqlMigrations\Revision\Revision20181121094934CreateATable;
 use Tests\Fixtures\BenChallis\SqlMigrations\Revision\Revision20181217101234CreateAnotherTable;
 use Tests\Fixtures\BenChallis\SqlMigrations\Revision\Revision20181222101234UpdateATable;
+use Tests\Helper\BenChallis\SqlMigrations\MigrationAsserter;
 
 abstract class MigrationsSpec extends AsyncTestCase
 {
@@ -42,16 +43,16 @@ abstract class MigrationsSpec extends AsyncTestCase
                 ),
             ),
             new Migration(
-                $createAnotherTable,
+                $updateATable,
                 Metadata::with(
-                    $versionExtractor->fromInstance($createAnotherTable),
+                    $versionExtractor->fromInstance($updateATable),
                     State::Unapplied,
                 ),
             ),
             new Migration(
-                $updateATable,
+                $createAnotherTable,
                 Metadata::with(
-                    $versionExtractor->fromInstance($updateATable),
+                    $versionExtractor->fromInstance($createAnotherTable),
                     State::Unapplied,
                 ),
             ),
@@ -68,6 +69,20 @@ abstract class MigrationsSpec extends AsyncTestCase
         foreach ($this->expectedMigrations() as $expectedMigration) {
             self::assertNotNull($all->filter(static fn (Migration $migration): bool => $expectedMigration->equals($migration))->first());
         }
+
+        $versionExtractor = new VersionExtractor();
+        MigrationAsserter::assertThat($all->toArray()[0])
+            ->hasVersion($versionExtractor->fromClass(Revision20181121094934CreateATable::class))
+            ->hasRevisionClass(Revision20181121094934CreateATable::class)
+            ->isInState(State::Applied);
+        MigrationAsserter::assertThat($all->toArray()[1])
+            ->hasVersion($versionExtractor->fromClass(Revision20181217101234CreateAnotherTable::class))
+            ->hasRevisionClass(Revision20181217101234CreateAnotherTable::class)
+            ->isInState(State::Unapplied);
+        MigrationAsserter::assertThat($all->toArray()[2])
+            ->hasVersion($versionExtractor->fromClass(Revision20181222101234UpdateATable::class))
+            ->hasRevisionClass(Revision20181222101234UpdateATable::class)
+            ->isInState(State::Unapplied);
     }
 
     /**


### PR DESCRIPTION
* Previously wasn't making any attempt to guarantee order
* Change `MigrationsSpec` to provide expected migrations out of order
* Assert order of migrations returned from `Migrations::getAll()`.