### PR TITLE
Document Version and MetadataStore

### DIFF
--- a/src/Migration/Metadata/MetadataStore.php
+++ b/src/Migration/Metadata/MetadataStore.php
@@ -7,17 +7,27 @@ namespace BenChallis\SqlMigrations\Migration\Metadata;
 use BenChallis\SqlMigrations\Migration\Version;
 use Psl\Collection\MapInterface;
 
+/**
+ * A store of migration metadata, usually persisted.
+ */
 interface MetadataStore
 {
+    /**
+     * Saves a migration's metadata.
+     */
     public function save(Metadata $metadata): void;
 
     /**
-     * @throws MetadataDoesNotExist
+     * Fetches a migration's metadata by version.
+     *
+     * @throws MetadataDoesNotExist If the metadata does not exist in the store.
      */
     public function fetch(Version $version): Metadata;
 
     /**
-     * @return MapInterface<int, Metadata>
+     * Fetches all migration metadata from the store.
+     *
+     * @return MapInterface<int, Metadata> A map of metadata keyed by version.
      */
     public function fetchAll(): MapInterface;
 }

--- a/src/Migration/Version.php
+++ b/src/Migration/Version.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace BenChallis\SqlMigrations\Migration;
 
+/**
+ * A migration's schema version.
+ *
+ * The schema versions are treated as being in ascending order, but not sequential.
+ */
 final class Version
 {
     /**


### PR DESCRIPTION
* `MetadataStore` usually deals with persistence.
* `MetadataStore::fetchAll()` keys on version.
* `Version` is assumed to be ascending in order, but not sequential.