### PR TITLE
Document the purposes of Migrations and its implementations

### DIFF
--- a/src/Migration/InMemoryMigrations.php
+++ b/src/Migration/InMemoryMigrations.php
@@ -11,6 +11,9 @@ use Psl\Collection\Vector;
 use Psl\Collection\VectorInterface;
 use Psl\Dict;
 
+/**
+ * In-memory state of migrations, requiring data upfront.
+ */
 final class InMemoryMigrations implements Migrations
 {
     /**

--- a/src/Migration/LazyLoadingMigrations.php
+++ b/src/Migration/LazyLoadingMigrations.php
@@ -7,6 +7,9 @@ namespace BenChallis\SqlMigrations\Migration;
 use BenChallis\SqlMigrations\Migration\Metadata\State;
 use Psl\Collection\VectorInterface;
 
+/**
+ * Defers loading migrations until interaction.
+ */
 final class LazyLoadingMigrations implements Migrations
 {
     /**

--- a/src/Migration/MetadataUpdatingMigrations.php
+++ b/src/Migration/MetadataUpdatingMigrations.php
@@ -9,6 +9,9 @@ use BenChallis\SqlMigrations\Migration\Metadata\MetadataStore;
 use BenChallis\SqlMigrations\Migration\Metadata\State;
 use Psl\Collection\VectorInterface;
 
+/**
+ * Decorator that updates a {@see MetadataStore} when state changes are performed.
+ */
 final class MetadataUpdatingMigrations implements Migrations
 {
     public function __construct(

--- a/src/Migration/Migrations.php
+++ b/src/Migration/Migrations.php
@@ -8,6 +8,9 @@ use BenChallis\SqlMigrations\Migration\Metadata\CannotTransitionState;
 use BenChallis\SqlMigrations\Migration\Metadata\State;
 use Psl\Collection\VectorInterface;
 
+/**
+ * The central access point into available migrations.
+ */
 interface Migrations
 {
     /**


### PR DESCRIPTION
* `Migrations` acts as the central point of access.
* `LazyLoadingMigrations` defers loading until required.
* `InMemoryMigrations` is an in-memory representation requiring data upfront.
* `MetadataStoreUpdatingMigrations` ensures a `MetadataStore` is kept up to date of state changes.