### PR TITLE
Add concrete exception for inability to instantiate a revision

### DIFF
--- a/src/Migration/Revision/CannotInstantiateRevision.php
+++ b/src/Migration/Revision/CannotInstantiateRevision.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BenChallis\SqlMigrations\Migration\Revision;
+
+final class CannotInstantiateRevision extends \RuntimeException
+{
+    private function __construct(string $message, ?\Throwable $previous = null)
+    {
+        parent::__construct($message, previous: $previous);
+    }
+
+    /**
+     * @param class-string<Revision> $class
+     */
+    public static function forClass(string $class, ?\Throwable $previous = null): self
+    {
+        return new self(\sprintf('Cannot instantiate revision "%s".', $class), $previous);
+    }
+}

--- a/src/Migration/Revision/RevisionFactory.php
+++ b/src/Migration/Revision/RevisionFactory.php
@@ -12,6 +12,8 @@ interface RevisionFactory
      * @param class-string<T> $revisionClass
      *
      * @return T
+     *
+     * @throws CannotInstantiateRevision
      */
     public function create(string $revisionClass): Revision;
 }

--- a/src/Migration/Revision/SimpleRevisionFactory.php
+++ b/src/Migration/Revision/SimpleRevisionFactory.php
@@ -11,6 +11,15 @@ final class SimpleRevisionFactory implements RevisionFactory
 {
     public function create(string $revisionClass): Revision
     {
+        $constructor = (new \ReflectionClass($revisionClass))->getConstructor();
+
+        if ($constructor !== null && ($constructor->getNumberOfParameters() > 0 || !$constructor->isPublic())) {
+            throw CannotInstantiateRevision::forClass(
+                $revisionClass,
+                new \RuntimeException('The class does not have a zero parameter public constructor.'),
+            );
+        }
+
         return new $revisionClass();
     }
 }

--- a/tests/fixtures/Revision/RevisionWithConstructorHavingParameters.php
+++ b/tests/fixtures/Revision/RevisionWithConstructorHavingParameters.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\BenChallis\SqlMigrations\Revision;
+
+use Amp\Sql\Executor;
+use BenChallis\SqlMigrations\Migration\Revision\Revision;
+
+final class RevisionWithConstructorHavingParameters implements Revision
+{
+    public function __construct(private readonly string $foo) // @phpstan-ignore-line
+    {
+    }
+
+    public function apply(Executor $executor): void
+    {
+    }
+
+    public function revert(Executor $executor): void
+    {
+    }
+}

--- a/tests/fixtures/Revision/RevisionWithPrivateConstructor.php
+++ b/tests/fixtures/Revision/RevisionWithPrivateConstructor.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Fixtures\BenChallis\SqlMigrations\Revision;
+
+use Amp\Sql\Executor;
+use BenChallis\SqlMigrations\Migration\Revision\Revision;
+
+final class RevisionWithPrivateConstructor implements Revision
+{
+    private function __construct()
+    {
+    }
+
+    public function apply(Executor $executor): void
+    {
+    }
+
+    public function revert(Executor $executor): void
+    {
+    }
+}

--- a/tests/helper/ServiceNotFound.php
+++ b/tests/helper/ServiceNotFound.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Helper\BenChallis\SqlMigrations;
+
+use Psr\Container\NotFoundExceptionInterface;
+
+final class ServiceNotFound extends \RuntimeException implements NotFoundExceptionInterface
+{
+}

--- a/tests/helper/SimpleServiceLocator.php
+++ b/tests/helper/SimpleServiceLocator.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Helper\BenChallis\SqlMigrations;
+
+use Psl\Collection\Map;
+use Psl\Collection\MapInterface;
+use Psr\Container\ContainerInterface;
+
+final class SimpleServiceLocator implements ContainerInterface
+{
+    /**
+     * @var MapInterface<string, mixed>
+     */
+    private readonly MapInterface $services;
+
+    /**
+     * @param array<string, mixed> $services
+     */
+    public function __construct(array $services)
+    {
+        $this->services = new Map($services);
+    }
+
+    public function get(string $id)
+    {
+        if (!$this->has($id)) {
+            throw new ServiceNotFound();
+        }
+
+        return $this->services->get($id);
+    }
+
+    public function has(string $id): bool
+    {
+        return $this->services->contains($id);
+    }
+}

--- a/tests/unit/Migration/Revision/ServiceLocatorRevisionFactoryTest.php
+++ b/tests/unit/Migration/Revision/ServiceLocatorRevisionFactoryTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\BenChallis\SqlMigrations\Migration\Revision;
+
+use BenChallis\SqlMigrations\Migration\Revision\CannotInstantiateRevision;
+use BenChallis\SqlMigrations\Migration\Revision\ServiceLocatorRevisionFactory;
+use PHPUnit\Framework\TestCase;
+use Tests\Fixtures\BenChallis\SqlMigrations\Revision\Revision20181121094934CreateATable;
+use Tests\Fixtures\BenChallis\SqlMigrations\Revision\Revision20181222101234UpdateATable;
+use Tests\Helper\BenChallis\SqlMigrations\SimpleServiceLocator;
+
+/**
+ * @covers \BenChallis\SqlMigrations\Migration\Revision\ServiceLocatorRevisionFactory
+ */
+final class ServiceLocatorRevisionFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function can_obtain_revisions_from_a_service_locator(): void
+    {
+        $revision = new Revision20181121094934CreateATable();
+        $locator = new SimpleServiceLocator(
+            [
+                $revision::class => $revision,
+            ],
+        );
+
+        $factory = new ServiceLocatorRevisionFactory($locator);
+
+        self::assertSame($revision, $factory->create($revision::class));
+    }
+
+    /**
+     * @test
+     */
+    public function throws_if_locator_does_not_have_service(): void
+    {
+        $this->expectException(CannotInstantiateRevision::class);
+
+        $locator = new SimpleServiceLocator([]);
+
+        (new ServiceLocatorRevisionFactory($locator))->create(Revision20181121094934CreateATable::class);
+    }
+
+    /**
+     * @test
+     */
+    public function throws_if_returned_instance_type_from_locator_differs_to_expected(): void
+    {
+        $this->expectException(CannotInstantiateRevision::class);
+
+        $locator = new SimpleServiceLocator(
+            [
+                Revision20181121094934CreateATable::class => new Revision20181222101234UpdateATable(),
+            ],
+        );
+
+        (new ServiceLocatorRevisionFactory($locator))->create(Revision20181121094934CreateATable::class);
+    }
+}

--- a/tests/unit/Migration/Revision/SimpleRevisionFactoryTest.php
+++ b/tests/unit/Migration/Revision/SimpleRevisionFactoryTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace Tests\Unit\BenChallis\SqlMigrations\Migration\Revision;
 
+use BenChallis\SqlMigrations\Migration\Revision\CannotInstantiateRevision;
 use BenChallis\SqlMigrations\Migration\Revision\SimpleRevisionFactory;
 use PHPUnit\Framework\TestCase;
 use Tests\Fixtures\BenChallis\SqlMigrations\Revision\Revision20181121094934CreateATable;
+use Tests\Fixtures\BenChallis\SqlMigrations\Revision\RevisionWithConstructorHavingParameters;
+use Tests\Fixtures\BenChallis\SqlMigrations\Revision\RevisionWithPrivateConstructor;
 
 /**
  * @covers \BenChallis\SqlMigrations\Migration\Revision\SimpleRevisionFactory
@@ -23,5 +26,25 @@ final class SimpleRevisionFactoryTest extends TestCase
         $instance = $factory->create(Revision20181121094934CreateATable::class);
 
         self::assertInstanceOf(Revision20181121094934CreateATable::class, $instance); // @phpstan-ignore-line want to verify the behaviour despite types.
+    }
+
+    /**
+     * @test
+     */
+    public function throws_if_revision_has_parameters_in_public_constructor(): void
+    {
+        $this->expectException(CannotInstantiateRevision::class);
+
+        (new SimpleRevisionFactory())->create(RevisionWithConstructorHavingParameters::class);
+    }
+
+    /**
+     * @test
+     */
+    public function throws_if_revision_does_not_have_public_constructor(): void
+    {
+        $this->expectException(CannotInstantiateRevision::class);
+
+        (new SimpleRevisionFactory())->create(RevisionWithPrivateConstructor::class);
     }
 }


### PR DESCRIPTION
Also harden validation of types of revision and if a revision can be constructed directly rather than letting it explode.